### PR TITLE
Fix conda activation on Windows using conda run & python/python3 

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -24,7 +24,7 @@ function getPlatformSpecificCommand(pythonCommand) {
     const isWindows = platform() === 'win32';
     if (isWindows) {
         return {
-            command: `conda activate ${CONDA_ENV_NAME} && ${pythonCommand}`,
+            command: `conda run -n ${CONDA_ENV_NAME} ${pythonCommand}`,
             options: {
                 shell: 'cmd.exe'
             }
@@ -47,7 +47,7 @@ async function executeCode(code, filePath) {
         // Write code to file
         await writeFile(filePath, code, 'utf-8');
         // Get platform-specific command
-        const pythonCmd = `python3 "${filePath}"`;
+        const pythonCmd = platform() === 'win32' ? `python "${filePath}"` : `python3 "${filePath}"`;
         const { command, options } = getPlatformSpecificCommand(pythonCmd);
         // Execute code
         const { stdout, stderr } = await execAsync(command, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ function getPlatformSpecificCommand(pythonCommand: string): { command: string, o
     
     if (isWindows) {
         return {
-            command: `conda activate ${CONDA_ENV_NAME} && ${pythonCommand}`,
+            command: `conda run -n ${CONDA_ENV_NAME} ${pythonCommand}`,
             options: {
                 shell: 'cmd.exe'
             }
@@ -58,7 +58,7 @@ async function executeCode(code: string, filePath: string) {
         await writeFile(filePath, code, 'utf-8');
 
         // Get platform-specific command
-        const pythonCmd = `python3 "${filePath}"`;
+        const pythonCmd = platform() === 'win32' ? `python "${filePath}"` : `python3 "${filePath}"`;
         const { command, options } = getPlatformSpecificCommand(pythonCmd);
 
         // Execute code


### PR DESCRIPTION
   This PR fixes an issue with conda activation on Windows environments described in Issue 3
   https://github.com/bazinga012/mcp_code_executor/issues/3#issue-2921356749

   ## Problem
   The current implementation uses `conda activate` which doesn't work properly in the Node.js execution context on Windows systems, resulting in an error:
   ```
   conda-script.py: error: argument COMMAND: invalid choice: 'activate'...
   ```

   ## Solution
   - Changed to use `conda run -n <env_name>` for Windows environments which works reliably
   - Updated Python command to use `python` instead of `python3` on Windows systems as that's the typical command name in Windows conda environments

   These changes improve compatibility with Windows systems while maintaining the existing behavior on Unix-based systems.

## Note:  Most standard Windows Python installations (from python.org) register python as the command, not python3
However, if Python was installed via Microsoft Store, WSL, or certain third-party distributions, python3 might be available
Conda environments typically use python regardless of the Python version.  This logic should handle all scenarios.